### PR TITLE
Integrate frontend with backend auth

### DIFF
--- a/companyRegistration.html
+++ b/companyRegistration.html
@@ -20,25 +20,22 @@
 </header>
 <div class="container">
     <h1 class="title">Регистрация</h1>
-    <form class="form">
-        <input type="text" placeholder="Название компании" class="form-input">
-        <input type="email" placeholder="Электронная почта" class="form-input">
-        <input type="tel" placeholder="Контактный номер телефона" class="form-input">
-        <input type="tel" placeholder="ФИО представителя" class="form-input">
-        <input type="tel" placeholder="Должность представителя" class="form-input">
-        <input type="tel" placeholder="ИНН/ОГРН" class="form-input">
-        <input type="tel" placeholder="Юридический адрес" class="form-input">
-        <input type="tel" placeholder="Тип услуг" class="form-input">
-        <input type="password" placeholder="Пароль" class="form-input">
+    <form class="form companyRegistrationForm">
+        <input type="text" placeholder="Название компании" class="form-input companyName">
+        <input type="email" placeholder="Электронная почта" class="form-input companyEmail">
+        <input type="tel" placeholder="Контактный номер телефона" class="form-input companyPhone">
+        <input type="text" placeholder="ФИО представителя" class="form-input agentName">
+        <input type="text" placeholder="Должность представителя" class="form-input agentPosition">
+        <input type="text" placeholder="ИНН/ОГРН" class="form-input companyId">
+        <input type="text" placeholder="Юридический адрес" class="form-input companyAddress">
+        <input type="text" placeholder="Тип услуг" class="form-input serviceType">
+        <input type="password" placeholder="Пароль" class="form-input companyPassword">
         <input type="password" placeholder="Повторите пароль" class="form-input">
         <label for="file-upload" class="attach-link">Прикрепить документы</label>
-        <input type="file" id="file-upload" style="display: none;">
+        <input type="file" id="file-upload" style="display: none;" multiple>
+        <button type="submit" class="button registerSubmit">Зарегистрироваться</button>
     </form>
-    <div class="button-group">
-        <a href="companyProfile.html">
-            <button class="button">Зарегистрироваться</button>
-        </a>
-    </div>
 </div>
+<script src="scripts/companyRegister.js"></script>
 </body>
 </html>

--- a/scripts/companyRegister.js
+++ b/scripts/companyRegister.js
@@ -1,0 +1,49 @@
+const API_BASE = 'http://176.57.215.221:8080/';
+const form = document.querySelector('.companyRegistrationForm');
+
+async function handleCompanyRegister(event) {
+  event.preventDefault();
+  const body = {
+    user: {
+      register: {
+        company_name: document.querySelector('.companyName').value,
+        email: document.querySelector('.companyEmail').value,
+        phone: document.querySelector('.companyPhone').value,
+        full_name: document.querySelector('.agentName').value,
+        position_agent: document.querySelector('.agentPosition').value,
+        id_company: document.querySelector('.companyId').value,
+        address: document.querySelector('.companyAddress').value,
+        type_service: document.querySelector('.serviceType').value,
+        password: document.querySelector('.companyPassword').value,
+        photo: null,
+        documents: [],
+        type: 'company'
+      }
+    }
+  };
+  try {
+    const response = await fetch(`${API_BASE}v1/register/company`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(body)
+    });
+    const data = await response.json();
+    if (response.ok) {
+      const { token, type } = data.user;
+      localStorage.setItem('authToken', token);
+      localStorage.setItem('accountType', type);
+      document.cookie = `authToken=${token}; path=/`;
+      window.location.href = 'companyProfile.html';
+    } else {
+      console.error('Registration error');
+    }
+  } catch (err) {
+    console.error('Ошибка:', err);
+  }
+}
+
+if (form) {
+  form.addEventListener('submit', handleCompanyRegister);
+}

--- a/scripts/login.js
+++ b/scripts/login.js
@@ -31,11 +31,18 @@ async function handleLogin(event) {
       const data = await response.json(); // Разбираем JSON-ответ
 
       if (response.ok) { // Вход прошел успешно
-        // Сохраняем токен в localStorage и cookie
-        localStorage.setItem('authToken', data.user.token);
-        document.cookie = `authToken=${data.user.token}; path=/`;
+        const { token, type } = data.user;
+        // Сохраняем токен и тип аккаунта
+        localStorage.setItem('authToken', token);
+        localStorage.setItem('accountType', type);
+        document.cookie = `authToken=${token}; path=/`;
 
-        window.location.href = 'companyProfile.html';
+        // Перенаправляем в кабинет в зависимости от типа
+        if (type === 'company') {
+          window.location.href = 'companyProfile.html';
+        } else {
+          window.location.href = 'customerProfile.html';
+        }
 
       } else {
         alert('Ошибка!!!!')

--- a/scripts/register.js
+++ b/scripts/register.js
@@ -36,12 +36,18 @@ async function handleRegister(event) {
       const data = await response.json(); // Разбираем JSON-ответ
 
       if (response.ok) {
-        // Сохраняем токен в localStorage и cookie
-        localStorage.setItem('authToken', data.user.token);
-        document.cookie = `authToken=${data.user.token}; path=/`;
+        const { token, type } = data.user;
+        // Сохраняем токен и тип аккаунта
+        localStorage.setItem('authToken', token);
+        localStorage.setItem('accountType', type);
+        document.cookie = `authToken=${token}; path=/`;
 
-        // Перенаправляем на страницу для авторизованных пользователей (замените 'dashboard.html' на ваш URL)
-        window.location.href = 'companyProfile.html';
+        // Перенаправляем на страницу для авторизованных пользователей
+        if (type === 'company') {
+          window.location.href = 'companyProfile.html';
+        } else {
+          window.location.href = 'customerProfile.html';
+        }
 
       } else {
       }


### PR DESCRIPTION
## Summary
- finish login and registration logic
- add script for company registration
- store auth token and type in cookie/localStorage
- redirect to profile page depending on account type

## Testing
- `curl -I http://176.57.215.221:8080/v1/login`

------
https://chatgpt.com/codex/tasks/task_e_68458d2797fc832e95a5017c03866347